### PR TITLE
Adjust mobile verb display in custom game

### DIFF
--- a/script.js
+++ b/script.js
@@ -430,7 +430,8 @@ function applyVerbSelection() {
         showToast('Please select at least one verb.', 'error');
         return;
     }
-    
+
+    document.body.classList.remove('custom-game');
     generateBoards();
     updateSelectedVerbsDisplay();
     closeVerbModal();
@@ -509,6 +510,7 @@ function startCustomGame() {
     }
 
     resetGame(false);
+    document.body.classList.add('custom-game');
 
     gameState.selectedVerbs = newVerbs;
     selectedTense = newTense;
@@ -1023,6 +1025,7 @@ function resetGame(confirmReset = true) {
     }
 
     if (proceed) {
+        document.body.classList.remove('custom-game');
         // Reset all ships to unplaced state
         Object.keys(gameState.ships).forEach(shipType => {
             gameState.ships[shipType].placed = false;

--- a/style.css
+++ b/style.css
@@ -907,6 +907,12 @@ main {
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+@media (max-width: 768px) {
+    body.custom-game .verb-tag {
+        font-size: 0.8rem;
+    }
+}
+
 /* Tooltip Styles */
 .tooltip-container {
     position: relative;


### PR DESCRIPTION
## Summary
- add `custom-game` body class management to detect custom game mode
- reduce verb tag font size on mobile when in custom game

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891cb45f5f883279eb5f5c83cb70c8d